### PR TITLE
Speed up MongoDB tests

### DIFF
--- a/src/main/java/com/johnstarich/moviematcher/CountedSet.java
+++ b/src/main/java/com/johnstarich/moviematcher/CountedSet.java
@@ -7,15 +7,13 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * Created by johnstarich on 5/8/16.
  */
-public class CountedSet<T> extends HashMap<T, AtomicLong> {
+public class CountedSet<T> extends HashMap<T, Long> {
 	public CountedSet() {
 		super();
 	}
 
 	public long count(T key) {
-		AtomicLong value = super.get(key);
-		if(value == null) return 0L;
-		return value.get();
+		return super.getOrDefault(key, 0L);
 	}
 
 	public CountedSet(int initialCapacity) {
@@ -28,12 +26,9 @@ public class CountedSet<T> extends HashMap<T, AtomicLong> {
 	}
 
 	public void add(T item) {
-		AtomicLong currentCount = get(item);
-		if(currentCount == null) {
-			currentCount = new AtomicLong(0L);
-			putIfAbsent(item, currentCount);
+		synchronized (this) {
+			put(item, getOrDefault(item, 0L) + 1L);
 		}
-		currentCount.incrementAndGet();
 	}
 
 	public void addAll(Collection<? extends T> c) {

--- a/src/main/java/com/johnstarich/moviematcher/store/MovieMatcherDatabase.java
+++ b/src/main/java/com/johnstarich/moviematcher/store/MovieMatcherDatabase.java
@@ -21,8 +21,7 @@ public class MovieMatcherDatabase {
 			config.addHost(mongoHost);
 		}
 		catch(UnknownHostException e) {
-			e.printStackTrace();
-			System.exit(1);
+			throw new RuntimeException("Could not connect to MongoDB host: " + mongoHost, e);
 		}
 		config.setDatabase("moviematcher");
 		config.setGlobalCacheValidTime(GLOBAL_CACHE_VALID_TIME);

--- a/src/test/java/com/johnstarich/moviematcher/CountedSetTest.java
+++ b/src/test/java/com/johnstarich/moviematcher/CountedSetTest.java
@@ -20,14 +20,14 @@ public class CountedSetTest extends TestCase {
 		List<String> elements = Arrays.asList("hello", "hello", "nope", "hello", "maybe");
 		CountedSet<String> set = new CountedSet<>();
 		set.addAll(elements);
-		assertEquals(set.count("hello"), 3);
-		assertEquals(set.count("nope"), 1);
-		assertEquals(set.count("maybe"), 1);
+		assertEquals(3, set.count("hello"), 3);
+		assertEquals(1, set.count("nope"), 1);
+		assertEquals(1, set.count("maybe"), 1);
 
 		CountedSet<String> set2 = new CountedSet<>(elements);
-		assertEquals(set2.count("hello"), 3);
-		assertEquals(set2.count("nope"), 1);
-		assertEquals(set2.count("maybe"), 1);
+		assertEquals(3, set2.count("hello"));
+		assertEquals(1, set2.count("nope"));
+		assertEquals(1, set2.count("maybe"));
 	}
 
 	public void testNotNull() throws Exception {

--- a/src/test/java/com/johnstarich/moviematcher/app/AbstractMongoDBTest.java
+++ b/src/test/java/com/johnstarich/moviematcher/app/AbstractMongoDBTest.java
@@ -1,9 +1,9 @@
 package com.johnstarich.moviematcher.app;
 
 import com.johnstarich.moviematcher.store.ConfigManager;
-import com.mongodb.DB;
 import com.mongodb.Mongo;
 import com.mongodb.MongoClient;
+import com.mongodb.client.MongoCollection;
 import de.flapdoodle.embed.mongo.Command;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodProcess;
@@ -16,6 +16,8 @@ import de.flapdoodle.embed.process.extract.UserTempNaming;
 import de.flapdoodle.embed.process.io.Processors;
 import de.flapdoodle.embed.process.runtime.Network;
 import junit.framework.TestCase;
+
+import java.util.stream.StreamSupport;
 
 /**
  * Created by johnstarich on 4/14/16.
@@ -81,9 +83,13 @@ public abstract class AbstractMongoDBTest extends TestCase {
 	@Override
 	protected void tearDown() throws Exception {
 		super.tearDown();
-		mongo.getUsedDatabases()
-			.parallelStream()
-			.forEach(DB::dropDatabase);
+		StreamSupport.stream(mongo.listDatabaseNames().spliterator(), true)
+			.map(mongo::getDatabase)
+			.forEach(db ->
+				StreamSupport.stream(db.listCollectionNames().spliterator(), true)
+					.map(db::getCollection)
+					.forEach(MongoCollection::drop)
+			);
 	}
 
 	protected void tearDownAll() throws Exception {

--- a/src/test/java/com/johnstarich/moviematcher/models/AbstractModelTest.java
+++ b/src/test/java/com/johnstarich/moviematcher/models/AbstractModelTest.java
@@ -15,11 +15,12 @@ import java.util.Optional;
  */
 public class AbstractModelTest extends AbstractMongoDBTest {
 	public void testSave() throws Exception {
+		MovieMatcherDatabase.morphium.getDatabase().dropDatabase(); // cleanup from other test cases
 		DBTester obj = new DBTester(new ObjectId(), "test");
 		DBCollection collection = MovieMatcherDatabase.morphium.getDatabase().getCollection("d_b_tester");
-		assertEquals(collection.count(), 0);
+		assertEquals(0, collection.count());
 		obj.save();
-		assertEquals(collection.count(), 1);
+		assertEquals(1, collection.count());
 	}
 
 	public void testLoad() throws Exception {
@@ -50,9 +51,10 @@ public class AbstractModelTest extends AbstractMongoDBTest {
 	}
 
 	public void testSearch() throws Exception {
+		MovieMatcherDatabase.morphium.getDatabase().dropDatabase(); // cleanup from other test cases
 		DBTester obj = new DBTester(new ObjectId(), "test").save();
 		List<DBTester> results = AbstractModel.search(DBTester.class, "test");
-		assertEquals(results.size(), 1);
+		assertEquals(1, results.size());
 		assertEquals(obj, results.get(0));
 	}
 }

--- a/src/test/java/com/johnstarich/moviematcher/models/MovieTest.java
+++ b/src/test/java/com/johnstarich/moviematcher/models/MovieTest.java
@@ -2,15 +2,10 @@ package com.johnstarich.moviematcher.models;
 
 import com.johnstarich.moviematcher.app.AbstractMongoDBTest;
 import com.johnstarich.moviematcher.store.MovieMatcherDatabase;
-import com.mongodb.client.MongoCollection;
-import org.bson.Document;
 import org.bson.types.ObjectId;
-import org.junit.Test;
 
 import java.util.Date;
 import java.util.List;
-
-import static org.junit.Assert.*;
 
 /**
  * Created by johnstarich on 4/17/16.
@@ -23,10 +18,10 @@ public class MovieTest extends AbstractMongoDBTest {
 			.save();
 
 		List<Movie> movieList = AbstractModel.search(Movie.class, "Creed");
-		assertNotEquals(0, movieList.size());
+		assertNotSame(0, movieList.size());
 
 		movieList = AbstractModel.search(Movie.class, "The Dark Knight");
-		assertNotEquals(0, movieList.size());
+		assertNotSame(0, movieList.size());
 		assertEquals(true, movieList.get(0).title.contains("Dark"));
 
 		movieList = AbstractModel.search(Movie.class, "aklsjdflkj ajjasdkfj ajsfojoasjdfl");

--- a/src/test/java/com/johnstarich/moviematcher/models/SessionTest.java
+++ b/src/test/java/com/johnstarich/moviematcher/models/SessionTest.java
@@ -20,14 +20,18 @@ public class SessionTest extends AbstractMongoDBTest {
         Session s = new Session(new ObjectId(), Josue);
         s = s.save();
         /* need to drop expiration of two hours */
-        MovieMatcherDatabase.morphium.getDatabase().getCollection("session").dropIndex(
-                new BasicDBObject("created_at", 1)
-        );
+        MovieMatcherDatabase.morphium
+            .getDatabase()
+            .getCollection("session")
+            .dropIndex(new BasicDBObject("created_at", 1));
 
         DBObject value = new BasicDBObject("created_at", 1);
         DBObject property = new BasicDBObject("expireAfterSeconds", 60);
         /* creates expiration for 60 seconds */
-        MovieMatcherDatabase.morphium.getDatabase().getCollection("session").createIndex(value, property);
+        MovieMatcherDatabase.morphium
+            .getDatabase()
+            .getCollection("session")
+            .createIndex(value, property);
 
         Josue = Josue.save();
 

--- a/src/test/java/com/johnstarich/moviematcher/models/UserTest.java
+++ b/src/test/java/com/johnstarich/moviematcher/models/UserTest.java
@@ -17,6 +17,14 @@ public class UserTest extends AbstractMongoDBTest {
 	private User John = new User(new ObjectId(), "jstarich@MovieMatcher.com", "John", "Starich");
 	private User Cesar = new User(new ObjectId(), "2cgonzalez@MovieMatcher.com", "Cesar", "Gonzalez");
 
+	@Override
+	public void tearDown() {
+		Josue.delete();
+		Jeremy.delete();
+		John.delete();
+		Cesar.delete();
+	}
+
 	public void testUserRegister() throws Exception {
 		Josue = Josue.register("goodPassword!");
 		Jeremy = Jeremy.register("betterPassword1");

--- a/src/test/java/com/johnstarich/moviematcher/models/UserTest.java
+++ b/src/test/java/com/johnstarich/moviematcher/models/UserTest.java
@@ -17,14 +17,6 @@ public class UserTest extends AbstractMongoDBTest {
 	private User John = new User(new ObjectId(), "jstarich@MovieMatcher.com", "John", "Starich");
 	private User Cesar = new User(new ObjectId(), "2cgonzalez@MovieMatcher.com", "Cesar", "Gonzalez");
 
-	@Override
-	public void tearDown() {
-		Josue.delete();
-		Jeremy.delete();
-		John.delete();
-		Cesar.delete();
-	}
-
 	public void testUserRegister() throws Exception {
 		Josue = Josue.register("goodPassword!");
 		Jeremy = Jeremy.register("betterPassword1");


### PR DESCRIPTION
- Speed up MongoDB tests:
  - Make MongoDB tests default to run without fixed process names
  - Allow for opt-in on fixed process names to prevent multiple firewall popups (Set MONGO_TEST environment variable to anything other than "")
  - Move MongoDB initialization into static class setup and change tearDown to only drop the database, not stop the instance
  - Fix assertEquals(expected, actual) parameter order
- Make MongoDB initialization error more helpful
- Fix AbstractModel update method and field name methods
- Fix CountedSet sometimes hitting race condition on addAll where count was not yet updated immediately afterwards
